### PR TITLE
Migrate documentation toolchain from MkDocs/Material to Zensical

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -14,19 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Configure Git Credentials
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
       - uses: actions/cache@v4
         with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache
+          key: zensical-${{ env.cache_id }}
+          path: ~/.cache/pip
           restore-keys: |
-            mkdocs-material-
-      - run: pip install mkdocs-material 
-      - run: mkdocs gh-deploy --force
+            zensical-
+      - run: pip install zensical==0.0.46
+      - run: zensical build
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,10 +51,10 @@ example/
 
 ## Documentation
 
-- **Generator:** MkDocs
+- **Generator:** Zensical
 - **Configuration:** `mkdocs.yml`
 - **Source directory:** `doc/`
-- **Theme:** Material for MkDocs
+- **Theme:** Material for MkDocs (via Zensical)
 - **Live site:** https://codandotv.github.io/eagle-eye/
 
 ## Distribution

--- a/doc/4-tooling.md
+++ b/doc/4-tooling.md
@@ -1,8 +1,8 @@
 # Tooling 🛠️
 
-## Mkdocs-material
+## Zensical
 
-### How to run mkdocs locally?
+### How to run the docs locally?
 
 - Create your virtual env:
 
@@ -16,16 +16,18 @@ python3 -m venv venv
 source venv/bin/activate
 ```
 
-- Install mkdocs-material:
+- Install Zensical (pinned version):
 
 ```shell
-pip install mkdocs-material
+pip install zensical==0.0.46
 ```
 
 - Start the local server:
 
 ```shell
-mkdocs serve --watch .
+zensical serve
 ```
 
 Access your documentation at `http://127.0.0.1:8000/`
+
+> Zensical is in active development — the version is pinned to avoid breakage. Bump manually when needed.


### PR DESCRIPTION
Migrates the project's documentation pipeline from MkDocs + Material for MkDocs to Zensical, as per ADR-0001.

### Changes

- **`.github/workflows/documentation.yml`**: Replace `mkdocs gh-deploy --force` with `zensical build` + `peaceiris/actions-gh-pages@v4` for GitHub Pages deployment. Remove `Configure Git Credentials` step (handled by the action). Update pip cache key to `zensical-`.
- **`doc/4-tooling.md`**: Update local dev instructions — install `zensical==0.0.46` instead of `mkdocs-material`, use `zensical serve` instead of `mkdocs serve`.
- **`AGENTS.md`**: Update generator and theme references.

### Notes

- `mkdocs.yml` is left untouched — Zensical reads it as-is.
- Zensical version is pinned (`0.0.46`) to avoid breakage from alpha releases.
- `peaceiris/actions-gh-pages` publishes `./site` to the `gh-pages` branch.